### PR TITLE
Minor changes to ensemble scheduling

### DIFF
--- a/test/test_automl/test_estimators.py
+++ b/test/test_automl/test_estimators.py
@@ -434,8 +434,8 @@ def test_binary(tmp_dir, output_dir, dask_client):
     assert score > 0.9, extract_msg_from_log(log_file_path)
     assert count_succeses(automl.cv_results_) > 0, extract_msg_from_log(log_file_path)
 
-    output_files = os.listdir(output_dir)
-    assert 'binary_test_dataset_test_1.predict' in output_files, extract_msg_from_log(log_file_path)
+    output_files = glob.glob(os.path.join(output_dir, 'binary_test_dataset_test_*.predict'))
+    assert len(output_files) > 0, (output_files, extract_msg_from_log(log_file_path))
 
 
 def test_classification_pandas_support(tmp_dir, output_dir, dask_client):

--- a/test/test_ensemble_builder/test_ensemble.py
+++ b/test/test_ensemble_builder/test_ensemble.py
@@ -523,11 +523,12 @@ def test_read_pickle_read_preds(ensemble_backend):
     )
     assert os.path.exists(ensemble_memory_file)
 
-    # Make sure we pickle the correct read preads
+    # Make sure we pickle the correct read preads and hash
     with (open(ensemble_memory_file, "rb")) as memory:
-        read_preds = pickle.load(memory)
+        read_preds, last_hash = pickle.load(memory)
 
     compare_read_preds(read_preds, ensbuilder.read_preds)
+    assert last_hash == ensbuilder.last_hash
 
     # Then create a new instance, which should automatically read this file
     ensbuilder2 = EnsembleBuilder(
@@ -540,6 +541,7 @@ def test_read_pickle_read_preds(ensemble_backend):
         max_models_on_disc=None,
         )
     compare_read_preds(ensbuilder2.read_preds, ensbuilder.read_preds)
+    assert ensbuilder2.last_hash == ensbuilder.last_hash
 
 
 def testPredict():


### PR DESCRIPTION
* use future.result() to wait for a future instead of active wait with
  sleep
* store hash of ensemble training data in status pickle file